### PR TITLE
feat: browse 페이지에 로그인 기능 추가

### DIFF
--- a/src/pages/browse/[userId].tsx
+++ b/src/pages/browse/[userId].tsx
@@ -1,11 +1,9 @@
-import {
-  GetServerSideProps,
+import type {
   GetStaticPaths,
   GetStaticProps,
-  InferGetServerSidePropsType,
   InferGetStaticPropsType,
 } from 'next';
-import { createServerSideHelpers } from '@trpc/react-query/server';
+import { useState, useEffect, useCallback } from 'react';
 import { api } from '~/utils/api';
 import { formatDistanceToNow } from 'date-fns';
 import styled from '@emotion/styled';
@@ -45,10 +43,79 @@ const FileCard = styled('div')({
 const BrowsePage = ({
   userId,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  const [token, setToken] = useState<string | null>(null);
+  const utils = api.useContext();
+
+  const { data: currentUser } = api.account.getCurrentUser.useQuery(undefined, {
+    enabled: !!token,
+  });
+
+  const signInMutation = api.account.signIn.useMutation({
+    onSuccess: (data) => {
+      setToken(data.token);
+      localStorage.setItem('authToken', data.token);
+      void utils.s3.listUserFiles.invalidate();
+    },
+  });
+
   const { data: filesData } = api.s3.listUserFiles.useQuery(
-    { userId },
-    { enabled: userId !== undefined }
+    undefined,
+    { enabled: !!token }
   );
+
+  const handleLogin = useCallback(async () => {
+    const email = window.prompt('Email:');
+    if (!email) return;
+
+    const password = window.prompt('Password:');
+    if (!password) return;
+
+    void signInMutation.mutate({ email, password });
+  }, [signInMutation]);
+
+  // Check for stored token on mount
+  useEffect(() => {
+    const storedToken = localStorage.getItem('authToken');
+    if (storedToken) {
+      if (!currentUser || currentUser.name === userId) {
+        setToken(storedToken);
+      } else {
+        localStorage.removeItem('authToken');
+      }
+    } else if (!signInMutation.isPending && !signInMutation.error) {
+      void handleLogin();
+    }
+  }, [currentUser, userId, handleLogin, signInMutation]);
+
+  if (signInMutation.error) {
+    return (
+      <Container>
+        <Title>Login Failed</Title>
+        <div className="text-center text-red-500">
+          Please refresh to try again.
+        </div>
+      </Container>
+    );
+  }
+
+  if (!token || !currentUser) {
+    return (
+      <Container>
+        <Title>Waiting for authentication...</Title>
+      </Container>
+    );
+  }
+
+  if (currentUser.name !== userId) {
+    return (
+      <Container>
+        <Title>Access Denied</Title>
+        <div className="text-center text-red-500">
+          You cannot access files that do not belong to you.
+        </div>
+      </Container>
+    );
+  }
 
   return (
     <Container>

--- a/src/pages/browse/index.tsx
+++ b/src/pages/browse/index.tsx
@@ -1,7 +1,6 @@
 import type {
-  GetStaticPaths,
-  GetStaticProps,
-  InferGetStaticPropsType,
+  GetServerSideProps,
+  InferGetServerSidePropsType
 } from 'next';
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '~/utils/api';
@@ -41,8 +40,8 @@ const FileCard = styled('div')({
 });
 
 const BrowsePage = ({
-  userId,
-}: InferGetStaticPropsType<typeof getStaticProps>) => {
+  login,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const [token, setToken] = useState<string | null>(null);
   const utils = api.useContext();
 
@@ -76,23 +75,19 @@ const BrowsePage = ({
   // Check for stored token on mount
   useEffect(() => {
     const storedToken = localStorage.getItem('authToken');
-    if (storedToken) {
-      if (!currentUser || currentUser.name === userId) {
-        setToken(storedToken);
-      } else {
-        localStorage.removeItem('authToken');
-      }
-    } else if (!signInMutation.isPending && !signInMutation.error) {
+    if (storedToken && !login) {
+      setToken(storedToken);
+    } else if (!signInMutation.isSuccess && !signInMutation.isPending && !signInMutation.error) {
       void handleLogin();
     }
-  }, [currentUser, userId, handleLogin, signInMutation]);
+  }, [currentUser, login, handleLogin, signInMutation]);
 
   if (signInMutation.error) {
     return (
       <Container>
-        <Title>Login Failed</Title>
+        <Title>Access Denied</Title>
         <div className="text-center text-red-500">
-          Please refresh to try again.
+          Login failed. Please refresh to try again.
         </div>
       </Container>
     );
@@ -102,16 +97,8 @@ const BrowsePage = ({
     return (
       <Container>
         <Title>Waiting for authentication...</Title>
-      </Container>
-    );
-  }
-
-  if (currentUser.name !== userId) {
-    return (
-      <Container>
-        <Title>Access Denied</Title>
         <div className="text-center text-red-500">
-          You cannot access files that do not belong to you.
+          Please refresh this page if nothing happens.
         </div>
       </Container>
     );
@@ -146,21 +133,14 @@ const BrowsePage = ({
   );
 };
 
-export const getStaticProps = (async ({ params }) => {
-  const userId = params!.userId as string;
+export const getServerSideProps = (async ({ query }) => {
+  const login = query?.login ?? null;
 
   return {
     props: {
-      userId,
+      login,
     },
   };
-}) satisfies GetStaticProps;
-
-export const getStaticPaths = (async () => {
-  return {
-    paths: [],
-    fallback: 'blocking',
-  };
-}) satisfies GetStaticPaths;
+}) satisfies GetServerSideProps;
 
 export default BrowsePage;

--- a/src/server/api/routers/s3.ts
+++ b/src/server/api/routers/s3.ts
@@ -6,10 +6,9 @@ import { env } from '~/env.js';
 import {
   createTRPCRouter,
   protectedProcedure,
-  publicProcedure,
 } from '~/server/api/trpc';
 export const s3Router = createTRPCRouter({
-  listUserFiles: publicProcedure
+  listUserFiles: protectedProcedure
     .meta({
       openapi: {
         method: 'GET',
@@ -19,7 +18,7 @@ export const s3Router = createTRPCRouter({
         description: 'Returns list of files uploaded by the current user',
       },
     })
-    .input(z.object({ userId: z.string() }))
+    .input(z.void())
     .output(
       z.object({
         files: z.array(
@@ -33,10 +32,13 @@ export const s3Router = createTRPCRouter({
         ),
       })
     )
-    .query(async ({ ctx, input: { userId } }) => {
+    .query(async ({ ctx }) => {
+      // Use the authenticated user's name from the session
+      const userName = ctx.session.user.name;
+
       const response = await ctx.s3.listObjectsV2({
         Bucket: env.BUCKET_NAME,
-        Prefix: `${userId}/`, // Only list objects that are in the user's folder
+        Prefix: `${userName}/`, // Only list objects that are in the user's folder
       });
 
       return {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -40,6 +40,11 @@ export const api = createTRPCNext<AppRouter>({
            */
           transformer: superjson,
           url: `${getBaseUrl()}/api/trpc`,
+          headers() {
+            // Add auth token to all requests
+            const token = localStorage.getItem("authToken");
+            return token ? { Authorization: `Bearer ${token}` } : {};
+          },
         }),
       ],
     };


### PR DESCRIPTION
# 설명
`/browse` 엔드포인트에 Bearer 인증을 통한 로그인 기능을 추가합니다. 

# 세부사항
- 기존의 `userId`를 path에 제공하여 접속하는 `/browse/[userId]` 방식에서, 모든 계정이 동일하게 `/browse`에 접속하는 방식으로 바뀌었습니다.
- `account.getCurrentUser`와 `account.signIn` API를 사용해야해서 약간 내용이 방대해지긴 했지만, `window.prompt` 같은 요소만을 사용해서 변경을 최소화 했습니다.
- 한번 로그인으로 접속한 뒤에는 토큰이 날라가지 않고 Local storage에 유지되어 편의성도 기존과 같이 유지됩니다.
- 한번 로그인 하면 다른 User의 endpoint 접속은 불가능하며, 로그인 실패 시에 Access Denied가 되는 등의 올바른 동작을 확인했습니다.
- Access Denied 시에 새로 고침하면 로그인 재시도도 할 수 있습니다. Query string으로 `?login=0`처럼 보내면 이전 계정의 토큰이 삭제되어 마찬가지로 로그인을 재시도 할 수 있습니다.

Github Copilot (Claude Sonnet 3.5) 으로 작성했기 때문에 최신 트렌드와 맞지 않거나 코드베이스 상의 설계 방식과 다를 수 있습니다. 조언 부탁드립니다!
